### PR TITLE
Compose On-The-Go

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source "https://rubygems.org"
 
 gem "github-pages"
 gem "rouge"
+
+group :jekyll_plugins do
+  gem "jekyll-compose"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,8 @@ GEM
       commonmarker (~> 0.17.6)
       jekyll-commonmark (~> 1)
       rouge (~> 2)
+    jekyll-compose (0.8.0)
+      jekyll (~> 3.0)
     jekyll-default-layout (0.1.4)
       jekyll (~> 3.0)
     jekyll-feed (0.10.0)
@@ -248,6 +250,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  jekyll-compose
   rouge
 
 BUNDLED WITH


### PR DESCRIPTION
Goodness-knows-how people post things in Jekyll. I could not keep up
with the naming, dating, and folder structure consistencies. I mean, why
should humans bother with something computers do better? I needed
something to take care of all the Jekyll nuances which I focus on
writing.

In this change, I

* installed `jekyll-compose`; so I can do `jekyll post Title`